### PR TITLE
Update ListViewRenderer.cs

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -609,6 +609,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				AView _trackedView;
 				int _trackedViewPrevPosition;
+				int _trackedViewPrevHeight;
 				int _trackedViewPrevTop;
 
 				public void SyncState(AbsListView view)
@@ -616,6 +617,7 @@ namespace Xamarin.Forms.Platform.Android
 					if (view.ChildCount > 0)
 					{
 						_trackedView = GetChild(view);
+						_trackedViewPrevHeight = view.Height;
 						_trackedViewPrevTop = GetY();
 						_trackedViewPrevPosition = view.GetPositionForView(_trackedView);
 					}
@@ -653,7 +655,7 @@ namespace Xamarin.Forms.Platform.Android
 				}
 				int GetY()
 				{
-					return _position <= 1 ? _trackedView.Bottom : _trackedView.Top;
+					return _position <= 1 ? (_trackedView.Bottom - (_trackedView.Height - _trackedViewPrevHeight)) : _trackedView.Top;
 				}
 			}
 
@@ -710,6 +712,9 @@ namespace Xamarin.Forms.Platform.Android
 						t.SyncState(view);
 					}
 				}
+				
+				if (!wasTracked)
+                    _contentOffset = 0;
 			}
 
 			public void OnScrollStateChanged(AbsListView view, ScrollState scrollState)


### PR DESCRIPTION
Fixes two issues with ListView scroll event ScrollY value that were making it pretty unreliable and buggy.

Original code was commited in [this commit](https://github.com/xamarin/Xamarin.Forms/commit/e85fcbcb87c5455b312ac46079c1b2cda34b6fe0#diff-ef4e030a3614a0c4819c7bffc5fd7b03)

_I'm not 100% sure if there can't be any other situation when the scroll fails to be tracked (maybe some fast scroll?), for which setting the  `_contentOffset` to `0` might not be correct, but it fixes the "reloaded ItemsSource" issue, which seems to be the most common. When we are not able to track the offset at all, it's a bug anyway, so setting the offset to 0 seems good because it solves this issue at least._

### Issues Resolved ### 
- fixes #8305
- fixes #9370

### API Changes ###
None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
ScrollY value in Scrolled event might sometimes be different than before, because it's now fixed.

### Testing Procedure ###
I tested the sample project in #8305 and #9370 and confirmed it is fixed. However, it might be good to test that setting the  `_contentOffset` to `0` doesn't create any side effects in different situations.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
